### PR TITLE
Add optional time support to days calculator

### DIFF
--- a/BabyName/UI/package-lock.json
+++ b/BabyName/UI/package-lock.json
@@ -11,7 +11,7 @@
         "lz-string": "^1.5.0"
       },
       "devDependencies": {
-        "webpack": "^5.100.2",
+        "webpack": "^5.101.3",
         "webpack-cli": "^6.0.1",
         "webpack-dev-server": "^5.2.2"
       }
@@ -3470,10 +3470,11 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.100.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.100.2.tgz",
-      "integrity": "sha512-QaNKAvGCDRh3wW1dsDjeMdDXwZm2vqq3zn6Pvq4rHOEOGSaUMgOOjG2Y9ZbIGzpfkJk9ZYTHpDqgDfeBDcnLaw==",
+      "version": "5.101.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.101.3.tgz",
+      "integrity": "sha512-7b0dTKR3Ed//AD/6kkx/o7duS8H3f1a4w3BYpIriX4BzIhjkn4teo05cptsxvLesHFKK5KObnadmCHBwGc+51A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -3485,7 +3486,7 @@
         "acorn-import-phases": "^1.0.3",
         "browserslist": "^4.24.0",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.2",
+        "enhanced-resolve": "^5.17.3",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
@@ -3605,6 +3606,7 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.2.tgz",
       "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -6212,9 +6214,9 @@
       }
     },
     "webpack": {
-      "version": "5.100.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.100.2.tgz",
-      "integrity": "sha512-QaNKAvGCDRh3wW1dsDjeMdDXwZm2vqq3zn6Pvq4rHOEOGSaUMgOOjG2Y9ZbIGzpfkJk9ZYTHpDqgDfeBDcnLaw==",
+      "version": "5.101.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.101.3.tgz",
+      "integrity": "sha512-7b0dTKR3Ed//AD/6kkx/o7duS8H3f1a4w3BYpIriX4BzIhjkn4teo05cptsxvLesHFKK5KObnadmCHBwGc+51A==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.7",
@@ -6227,7 +6229,7 @@
         "acorn-import-phases": "^1.0.3",
         "browserslist": "^4.24.0",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.2",
+        "enhanced-resolve": "^5.17.3",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",

--- a/BabyName/UI/package.json
+++ b/BabyName/UI/package.json
@@ -6,7 +6,7 @@
     "build": "dotnet fable src && webpack"
   },
   "devDependencies": {
-    "webpack": "^5.100.2",
+    "webpack": "^5.101.3",
     "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^5.2.2"
   },

--- a/BabyName/UI/public/days.html
+++ b/BabyName/UI/public/days.html
@@ -14,10 +14,23 @@
     <div class="inline-block">
         <label for="start-day">Start day:</label>
         <input id="start-day" type="date" />
+        <div id="start-time-wrapper" class="display-none">
+            <label for="start-time">Start time:</label>
+            <input id="start-time" type="time" value="00:00" />
+        </div>
     </div>
     <div class="inline-block">
         <label for="end-day">End day:</label>
         <input id="end-day" type="date" />
+        <div id="end-time-wrapper" class="display-none">
+            <label for="end-time">End time:</label>
+            <input id="end-time" type="time" value="00:00" />
+        </div>
+    </div>
+
+    <div>
+        <label for="enable-time" class="not-selectable">Enable time</label>
+        <input id="enable-time" type="checkbox" />
     </div>
 
     <p class="red" id="error"></p>

--- a/BabyName/UI/src/App.fsproj
+++ b/BabyName/UI/src/App.fsproj
@@ -12,6 +12,7 @@
     <Compile Include="Alcohol.fs" />
     <Compile Include="Heartbeat.fs" />
     <Compile Include="Memory.fs" />
+    <Compile Include="DaysCore.fs" />
     <Compile Include="Days.fs" />
     <Compile Include="Equation.fs" />
     <Compile Include="App.fs" />

--- a/BabyName/UI/src/Days.fs
+++ b/BabyName/UI/src/Days.fs
@@ -4,6 +4,12 @@ open System
 open Html
 open Browser.Types
 
+let private show id =
+    (fromId id).classList.remove "display-none"
+
+let private hide id =
+    (fromId id).classList.add "display-none"
+
 let private isWeekend (time: DateTime) =
     time.DayOfWeek = DayOfWeek.Saturday || time.DayOfWeek = DayOfWeek.Sunday
 
@@ -36,12 +42,75 @@ let private loadDate key (el: HTMLInputElement) =
         let saved = DateTime.Parse(x)
         el.valueAsDate <- saved.ToLocalTime()
 
+let private saveTime key (time: string) =
+    setLocalStorage key time
+
+let private loadTime key (el: HTMLInputElement) =
+    match getLocalStorageOrEmpty key with
+    | "" -> el.value <- "00:00"
+    | x -> el.value <- x
+
+let private formatDuration totalDays =
+    let totalMinutes = Math.Round(totalDays * 24.0 * 60.0) |> int
+    let days, minutesAfterDays = Math.DivRem(totalMinutes, 24 * 60)
+    let hours, minutes = Math.DivRem(minutesAfterDays, 60)
+    let daysText = formatDays days
+    let timeText =
+        match hours, minutes with
+        | 0, 0 -> ""
+        | 0, _ -> sprintf "%i minutes" minutes
+        | _, 0 -> sprintf "%i hours" hours
+        | _, _ -> sprintf "%i hours %i minutes" hours minutes
+    match daysText, timeText with
+    | "None", "" -> "None"
+    | "None", t -> t
+    | d, "" -> d
+    | d, t -> d + " " + t
+
+let private collectTime (start: DateTime) stop =
+    let start, stop, reverse =
+        if start > stop then stop, start, true else start, stop, false
+
+    let mutable cursor = DateTime(start.Year, start.Month, start.Day)
+    let mutable totalDays = 0.0
+    let mutable weekendDays = 0.0
+    let mutable monthRatio = 0.0
+
+    while cursor <= stop.Date do
+        let dayEnd = cursor.AddDays(1.0)
+        let overlapStart = if cursor < start then start else cursor
+        let overlapEnd = if dayEnd > stop then stop else dayEnd
+        let fraction = (overlapEnd - overlapStart).TotalDays
+        if fraction > 0.0 then
+            totalDays <- totalDays + fraction
+            if isWeekend cursor then weekendDays <- weekendDays + fraction
+            let daysInMonth = DateTime.DaysInMonth(cursor.Year, cursor.Month) |> float
+            monthRatio <- monthRatio + fraction / daysInMonth
+        cursor <- cursor.AddDays 1.0
+
+    (totalDays, weekendDays, monthRatio, reverse)
+
 let initDays () =
     let start = inputFromId "start-day"
     let stop = inputFromId "end-day"
+    let startTime = inputFromId "start-time"
+    let stopTime = inputFromId "end-time"
+    let enableTime = inputFromId "enable-time"
 
     loadDate "start-day" start
     loadDate "end-day" stop
+    loadTime "start-time" startTime
+    loadTime "end-time" stopTime
+
+    match getLocalStorageOrEmpty "enable-time" with
+    | "true" ->
+        enableTime.checked <- true
+        show "start-time-wrapper"
+        show "end-time-wrapper"
+    | _ ->
+        enableTime.checked <- false
+        hide "start-time-wrapper"
+        hide "end-time-wrapper"
 
     let collectDays (start: DateTime) stop =
         let rec collectDays' (cursor: DateTime) stop collectedDays collectedMonths =
@@ -73,16 +142,27 @@ let initDays () =
         if validate () then
             saveDate "start-day" start.valueAsDate
             saveDate "end-day" stop.valueAsDate
-            
-            errorEl.textContent <- ""
-            let (days, monthRatio), reverse = collectDays start.valueAsDate stop.valueAsDate
-            let daysCount = days |> List.length
-            let weekendCount = days |> List.filter isWeekend |> List.length
+            saveTime "start-time" startTime.value
+            saveTime "end-time" stopTime.value
 
-            totalDaysEl.textContent <- (if reverse then "-" else "") + (formatDays daysCount)
-            weekendDaysEl.textContent <- formatDays weekendCount
-            monthsEl.textContent <- formatMonth monthRatio
-            yearsEl.textContent <- (if reverse then "-" else "") + formatYear monthRatio
+            errorEl.textContent <- ""
+            setLocalStorage "enable-time" (if enableTime.checked then "true" else "false")
+            if enableTime.checked then
+                let startDateTime = start.valueAsDate.Date.Add(TimeSpan.Parse(startTime.value))
+                let stopDateTime = stop.valueAsDate.Date.Add(TimeSpan.Parse(stopTime.value))
+                let total, weekend, monthRatio, reverse = collectTime startDateTime stopDateTime
+                totalDaysEl.textContent <- (if reverse then "-" else "") + formatDuration total
+                weekendDaysEl.textContent <- formatDuration weekend
+                monthsEl.textContent <- formatMonth monthRatio
+                yearsEl.textContent <- (if reverse then "-" else "") + formatYear monthRatio
+            else
+                let (days, monthRatio), reverse = collectDays start.valueAsDate stop.valueAsDate
+                let daysCount = days |> List.length
+                let weekendCount = days |> List.filter isWeekend |> List.length
+                totalDaysEl.textContent <- (if reverse then "-" else "") + (formatDays daysCount)
+                weekendDaysEl.textContent <- formatDays weekendCount
+                monthsEl.textContent <- formatMonth monthRatio
+                yearsEl.textContent <- (if reverse then "-" else "") + formatYear monthRatio
         else
             errorEl.textContent <- "Error in date"
             totalDaysEl.textContent <- "-"
@@ -98,6 +178,16 @@ let initDays () =
 
     start |> onChangeWithCooldown 1000<ms> calculate
     stop |> onChangeWithCooldown 1000<ms> calculate
+    startTime |> onChangeWithCooldown 1000<ms> calculate
+    stopTime |> onChangeWithCooldown 1000<ms> calculate
+    enableTime |> onChange (fun _ ->
+        if enableTime.checked then
+            show "start-time-wrapper"
+            show "end-time-wrapper"
+        else
+            hide "start-time-wrapper"
+            hide "end-time-wrapper"
+        calculate ())
     (inputFromId "add-days-btn") |> onClick addDays
 
     calculate ()

--- a/BabyName/UI/src/Days.fs
+++ b/BabyName/UI/src/Days.fs
@@ -4,12 +4,6 @@ open System
 open Html
 open Browser.Types
 
-let private show id =
-    (fromId id).classList.remove "display-none"
-
-let private hide id =
-    (fromId id).classList.add "display-none"
-
 let private isWeekend (time: DateTime) =
     time.DayOfWeek = DayOfWeek.Saturday || time.DayOfWeek = DayOfWeek.Sunday
 

--- a/BabyName/UI/src/Days.fs
+++ b/BabyName/UI/src/Days.fs
@@ -3,9 +3,7 @@ module Days
 open System
 open Html
 open Browser.Types
-
-let private isWeekend (time: DateTime) =
-    time.DayOfWeek = DayOfWeek.Saturday || time.DayOfWeek = DayOfWeek.Sunday
+open DaysCore
 
 let private formatMonth (monthRatio: float) =
     sprintf "%.2f months" monthRatio
@@ -61,29 +59,6 @@ let private formatDuration totalDays =
     | d, "" -> d
     | d, t -> d + " " + t
 
-let private collectTime (start: DateTime) stop =
-    let start, stop, reverse =
-        if start > stop then stop, start, true else start, stop, false
-
-    let mutable cursor = DateTime(start.Year, start.Month, start.Day)
-    let mutable totalDays = 0.0
-    let mutable weekendDays = 0.0
-    let mutable monthRatio = 0.0
-
-    while cursor <= stop.Date do
-        let dayEnd = cursor.AddDays(1.0)
-        let overlapStart = if cursor < start then start else cursor
-        let overlapEnd = if dayEnd > stop then stop else dayEnd
-        let fraction = (overlapEnd - overlapStart).TotalDays
-        if fraction > 0.0 then
-            totalDays <- totalDays + fraction
-            if isWeekend cursor then weekendDays <- weekendDays + fraction
-            let daysInMonth = DateTime.DaysInMonth(cursor.Year, cursor.Month) |> float
-            monthRatio <- monthRatio + fraction / daysInMonth
-        cursor <- cursor.AddDays 1.0
-
-    (totalDays, weekendDays, monthRatio, reverse)
-
 let initDays () =
     let start = inputFromId "start-day"
     let stop = inputFromId "end-day"
@@ -105,20 +80,6 @@ let initDays () =
         enableTime.checked <- false
         hide "start-time-wrapper"
         hide "end-time-wrapper"
-
-    let collectDays (start: DateTime) stop =
-        let rec collectDays' (cursor: DateTime) stop collectedDays collectedMonths =
-            if cursor <= stop then
-                let daysInMonth = DateTime.DaysInMonth(cursor.Year, cursor.Month) |> float
-                let monthAddition = 1.0 / daysInMonth
-                collectDays' (cursor.AddDays 1) stop (cursor :: collectedDays) (collectedMonths + monthAddition)
-            else
-                (collectedDays, collectedMonths)
-        
-        if start > stop then
-            (collectDays' stop start List.empty 0.0, true)
-        else
-            (collectDays' start stop List.empty 0.0, false)
 
     let validate () =
         try

--- a/BabyName/UI/src/DaysCore.fs
+++ b/BabyName/UI/src/DaysCore.fs
@@ -1,0 +1,43 @@
+module DaysCore
+
+open System
+
+let isWeekend (time: DateTime) =
+    time.DayOfWeek = DayOfWeek.Saturday || time.DayOfWeek = DayOfWeek.Sunday
+
+let collectTime (start: DateTime) stop =
+    let start, stop, reverse =
+        if start > stop then stop, start, true else start, stop, false
+
+    let mutable cursor = DateTime(start.Year, start.Month, start.Day)
+    let mutable totalDays = 0.0
+    let mutable weekendDays = 0.0
+    let mutable monthRatio = 0.0
+
+    while cursor <= stop.Date do
+        let dayEnd = cursor.AddDays(1.0)
+        let overlapStart = if cursor < start then start else cursor
+        let overlapEnd = if dayEnd > stop then stop else dayEnd
+        let fraction = (overlapEnd - overlapStart).TotalDays
+        if fraction > 0.0 then
+            totalDays <- totalDays + fraction
+            if isWeekend cursor then weekendDays <- weekendDays + fraction
+            let daysInMonth = DateTime.DaysInMonth(cursor.Year, cursor.Month) |> float
+            monthRatio <- monthRatio + fraction / daysInMonth
+        cursor <- cursor.AddDays 1.0
+
+    (totalDays, weekendDays, monthRatio, reverse)
+
+let collectDays (start: DateTime) stop =
+    let rec collectDays' (cursor: DateTime) stop collectedDays collectedMonths =
+        if cursor <= stop then
+            let daysInMonth = DateTime.DaysInMonth(cursor.Year, cursor.Month) |> float
+            let monthAddition = 1.0 / daysInMonth
+            collectDays' (cursor.AddDays 1.0) stop (cursor :: collectedDays) (collectedMonths + monthAddition)
+        else
+            (collectedDays, collectedMonths)
+
+    if start > stop then
+        (collectDays' stop start [] 0.0, true)
+    else
+        (collectDays' start stop [] 0.0, false)

--- a/BabyName/UI/src/Html.fs
+++ b/BabyName/UI/src/Html.fs
@@ -29,6 +29,12 @@ let fromId id = document.getElementById id
 let areaFromId id = (fromId id) :?> HTMLTextAreaElement
 let inputFromId id = (fromId id) :?> HTMLInputElement
 
+let show id =
+    (fromId id).classList.remove "display-none"
+
+let hide id =
+    (fromId id).classList.add "display-none"
+
 let onChange action (el: HTMLElement) =
     el.onchange <- (fun _ -> action ())
 

--- a/BabyName/UI/tests/DaysTests.fsx
+++ b/BabyName/UI/tests/DaysTests.fsx
@@ -1,0 +1,57 @@
+#load "../src/DaysCore.fs"
+open System
+open DaysCore
+
+let assertEqual expected actual name =
+    if expected <> actual then
+        failwithf "%s: expected %A but got %A" name expected actual
+
+let testLeapYear () =
+    let (days, _), reverse = collectDays (DateTime(2024,2,27)) (DateTime(2024,3,1))
+    assertEqual false reverse "reverse flag"
+    assertEqual 4 (List.length days) "leap year day count"
+    assertEqual 0 (List.filter isWeekend days |> List.length) "leap year weekend count"
+
+let testWeekendCount () =
+    let (days, _), _ = collectDays (DateTime(2024,6,7)) (DateTime(2024,6,10))
+    assertEqual 4 (List.length days) "weekend total days"
+    assertEqual 2 (List.filter isWeekend days |> List.length) "weekend days"
+
+let testCollectTimeFraction () =
+    let start = DateTime(2024,6,1,12,0,0)
+    let stop = DateTime(2024,6,2,12,0,0)
+    let total, weekend, _, reverse = collectTime start stop
+    assertEqual false reverse "collectTime reverse"
+    assertEqual 1.0 total "collectTime total"
+    assertEqual 1.0 weekend "collectTime weekend"
+
+let testLongRange () =
+    let start = DateTime(2010,1,1)
+    let stop = DateTime(2020,12,31)
+    let (days, _), reverse = collectDays start stop
+    assertEqual false reverse "long range reverse"
+    let expectedDays = (stop - start).Days + 1
+    assertEqual expectedDays (List.length days) "long range total days"
+
+let testCollectTimeLongRange () =
+    let start = DateTime(2019,1,1)
+    let stop = DateTime(2021,1,1)
+    let total, weekend, _, reverse = collectTime start stop
+    assertEqual false reverse "long collectTime reverse"
+    assertEqual 731.0 total "long collectTime total"
+    let mutable dt = start
+    let mutable count = 0
+    while dt < stop do
+        if isWeekend dt then count <- count + 1
+        dt <- dt.AddDays 1.0
+    assertEqual (float count) weekend "long collectTime weekend"
+
+let run () =
+    testLeapYear()
+    testWeekendCount()
+    testCollectTimeFraction()
+    testLongRange()
+    testCollectTimeLongRange()
+    printfn "All tests passed"
+
+run()

--- a/BabyName/UI/tests/DaysTests.fsx
+++ b/BabyName/UI/tests/DaysTests.fsx
@@ -1,3 +1,4 @@
+// Run with dotnet fsi tests/DaysTests.fsx
 #load "../src/DaysCore.fs"
 
 open System

--- a/BabyName/UI/tests/DaysTests.fsx
+++ b/BabyName/UI/tests/DaysTests.fsx
@@ -1,4 +1,5 @@
 #load "../src/DaysCore.fs"
+
 open System
 open DaysCore
 
@@ -6,52 +7,109 @@ let assertEqual expected actual name =
     if expected <> actual then
         failwithf "%s: expected %A but got %A" name expected actual
 
+let assertAlmostEqual expected actual tolerance name =
+    if abs (expected - actual) >= tolerance then
+        failwithf "%s: expected %A but got %A" name expected actual
+
 let testLeapYear () =
-    let (days, _), reverse = collectDays (DateTime(2024,2,27)) (DateTime(2024,3,1))
+    let (days, _), reverse = collectDays (DateTime(2024, 2, 27)) (DateTime(2024, 3, 1))
     assertEqual false reverse "reverse flag"
     assertEqual 4 (List.length days) "leap year day count"
     assertEqual 0 (List.filter isWeekend days |> List.length) "leap year weekend count"
 
 let testWeekendCount () =
-    let (days, _), _ = collectDays (DateTime(2024,6,7)) (DateTime(2024,6,10))
+    let (days, _), _ = collectDays (DateTime(2024, 6, 7)) (DateTime(2024, 6, 10))
     assertEqual 4 (List.length days) "weekend total days"
     assertEqual 2 (List.filter isWeekend days |> List.length) "weekend days"
 
 let testCollectTimeFraction () =
-    let start = DateTime(2024,6,1,12,0,0)
-    let stop = DateTime(2024,6,2,12,0,0)
+    let start = DateTime(2024, 6, 1, 12, 0, 0)
+    let stop = DateTime(2024, 6, 2, 12, 0, 0)
     let total, weekend, _, reverse = collectTime start stop
     assertEqual false reverse "collectTime reverse"
-    assertEqual 1.0 total "collectTime total"
-    assertEqual 1.0 weekend "collectTime weekend"
+    assertAlmostEqual 1.0 total 1e-6 "collectTime total"
+    assertAlmostEqual 1.0 weekend 1e-6 "collectTime weekend"
 
 let testLongRange () =
-    let start = DateTime(2010,1,1)
-    let stop = DateTime(2020,12,31)
+    let start = DateTime(2010, 1, 1)
+    let stop = DateTime(2020, 12, 31)
     let (days, _), reverse = collectDays start stop
     assertEqual false reverse "long range reverse"
     let expectedDays = (stop - start).Days + 1
     assertEqual expectedDays (List.length days) "long range total days"
 
 let testCollectTimeLongRange () =
-    let start = DateTime(2019,1,1)
-    let stop = DateTime(2021,1,1)
+    let start = DateTime(2019, 1, 1)
+    let stop = DateTime(2021, 1, 1)
     let total, weekend, _, reverse = collectTime start stop
     assertEqual false reverse "long collectTime reverse"
-    assertEqual 731.0 total "long collectTime total"
+    assertAlmostEqual 731.0 total 1e-6 "long collectTime total"
     let mutable dt = start
     let mutable count = 0
+
     while dt < stop do
-        if isWeekend dt then count <- count + 1
+        if isWeekend dt then
+            count <- count + 1
+
         dt <- dt.AddDays 1.0
-    assertEqual (float count) weekend "long collectTime weekend"
+
+    assertAlmostEqual (float count) weekend 1e-6 "long collectTime weekend"
+
+let testReverseOrderDays () =
+    let start = DateTime(2024, 2, 27)
+    let stop = DateTime(2024, 3, 1)
+    let forward, _ = collectDays start stop
+    let (revDays, revRatio), reverse = collectDays stop start
+    assertEqual true reverse "reverse days flag"
+    assertEqual (List.length (fst forward)) (List.length revDays) "reverse days count"
+    assertAlmostEqual (snd forward) revRatio 1e-6 "reverse days month ratio"
+
+let testReverseOrderTime () =
+    let start = DateTime(2024, 2, 27, 6, 0, 0)
+    let stop = DateTime(2024, 3, 1, 6, 0, 0)
+    let totalF, weekendF, ratioF, _ = collectTime start stop
+    let totalR, weekendR, ratioR, reverse = collectTime stop start
+    assertEqual true reverse "reverse time flag"
+    assertAlmostEqual totalF totalR 1e-6 "reverse time total"
+    assertAlmostEqual weekendF weekendR 1e-6 "reverse time weekend"
+    assertAlmostEqual ratioF ratioR 1e-6 "reverse time ratio"
+
+let testCollectTimeMonthRatio () =
+    let start = DateTime(2024, 3, 1, 0, 0, 0)
+    let stop = DateTime(2024, 3, 2, 0, 0, 0)
+    let _, _, monthRatio, _ = collectTime start stop
+    assertAlmostEqual (1.0 / 31.0) monthRatio 1e-6 "collectTime month ratio"
+
+let testCollectDaysMonthRatio () =
+    let (days, monthRatio), _ =
+        collectDays (DateTime(2024, 3, 1)) (DateTime(2024, 3, 2))
+
+    assertEqual 2 (List.length days) "collectDays month ratio count"
+    assertAlmostEqual (2.0 / 31.0) monthRatio 1e-6 "collectDays month ratio"
+
+let testCrossMonthRatio () =
+    let (days, monthRatioDays), _ =
+        collectDays (DateTime(2024, 1, 31)) (DateTime(2024, 2, 1))
+
+    assertEqual 2 (List.length days) "cross month days count"
+    assertAlmostEqual ((1.0 / 31.0) + (1.0 / 29.0)) monthRatioDays 1e-6 "cross month days ratio"
+
+    let _, _, monthRatioTime, _ =
+        collectTime (DateTime(2024, 1, 31, 12, 0, 0)) (DateTime(2024, 2, 1, 12, 0, 0))
+
+    assertAlmostEqual ((0.5 / 31.0) + (0.5 / 29.0)) monthRatioTime 1e-6 "cross month time ratio"
 
 let run () =
-    testLeapYear()
-    testWeekendCount()
-    testCollectTimeFraction()
-    testLongRange()
-    testCollectTimeLongRange()
+    testLeapYear ()
+    testWeekendCount ()
+    testCollectTimeFraction ()
+    testLongRange ()
+    testCollectTimeLongRange ()
+    testReverseOrderDays ()
+    testReverseOrderTime ()
+    testCollectTimeMonthRatio ()
+    testCollectDaysMonthRatio ()
+    testCrossMonthRatio ()
     printfn "All tests passed"
 
-run()
+run ()


### PR DESCRIPTION
## Summary
- add time inputs and toggle to days calculator UI
- compute duration with hours/minutes when time enabled

## Testing
- `npm run build` *(fails: The application 'fable' does not exist. A compatible .NET SDK was not found. Requested SDK version: 9.0.108)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb9b5c05483238f03c23ca5d19102