### PR TITLE
Include final day when stop is midnight

### DIFF
--- a/BabyName/UI/src/DaysCore.fs
+++ b/BabyName/UI/src/DaysCore.fs
@@ -9,12 +9,16 @@ let collectTime (start: DateTime) stop =
     let start, stop, reverse =
         if start > stop then stop, start, true else start, stop, false
 
+    // If the stop time is exactly at midnight, extend it to include the full day
+    let stop =
+        if stop.TimeOfDay = TimeSpan.Zero then stop.AddDays 1.0 else stop
+
     let mutable cursor = DateTime(start.Year, start.Month, start.Day)
     let mutable totalDays = 0.0
     let mutable weekendDays = 0.0
     let mutable monthRatio = 0.0
 
-    while cursor <= stop.Date do
+    while cursor < stop do
         let dayEnd = cursor.AddDays(1.0)
         let overlapStart = if cursor < start then start else cursor
         let overlapEnd = if dayEnd > stop then stop else dayEnd

--- a/BabyName/UI/tests/DaysTests.fsx
+++ b/BabyName/UI/tests/DaysTests.fsx
@@ -44,7 +44,7 @@ let testCollectTimeLongRange () =
     let stop = DateTime(2021, 1, 1)
     let total, weekend, _, reverse = collectTime start stop
     assertEqual false reverse "long collectTime reverse"
-    assertAlmostEqual 731.0 total 1e-6 "long collectTime total"
+    assertAlmostEqual 732.0 total 1e-6 "long collectTime total"
     let mutable dt = start
     let mutable count = 0
 
@@ -79,7 +79,7 @@ let testCollectTimeMonthRatio () =
     let start = DateTime(2024, 3, 1, 0, 0, 0)
     let stop = DateTime(2024, 3, 2, 0, 0, 0)
     let _, _, monthRatio, _ = collectTime start stop
-    assertAlmostEqual (1.0 / 31.0) monthRatio 1e-6 "collectTime month ratio"
+    assertAlmostEqual (2.0 / 31.0) monthRatio 1e-6 "collectTime month ratio"
 
 let testCollectDaysMonthRatio () =
     let (days, monthRatio), _ =


### PR DESCRIPTION
## Summary
- extend stop time to include full day when provided at midnight
- adjust day iteration to use extended end time
- update tests for inclusive midnight stop behavior

## Testing
- `timeout 30s dotnet fsi tests/DaysTests.fsx`


------
https://chatgpt.com/codex/tasks/task_e_68c07c72a56c8323ad948257c6a1dcba